### PR TITLE
Added tests for prefixed cases, head|tail expr; should not work

### DIFF
--- a/parser/msch_CommPref.0
+++ b/parser/msch_CommPref.0
@@ -1,0 +1,4 @@
+hello()
+	head head id := 3;
+	head tail head islist not id;
+end;

--- a/parser/msch_CommPrefExpr.2
+++ b/parser/msch_CommPrefExpr.2
@@ -1,0 +1,4 @@
+hello()
+// that would be expr expr, needs brackets
+	head id * 3;
+end;

--- a/parser/msch_CommPrefExprPlus.2
+++ b/parser/msch_CommPrefExprPlus.2
@@ -1,0 +1,4 @@
+hello()
+// only head head term would be valid
+	head head id + id + 1;
+end;

--- a/parser/msch_CommPrefLexpr.0
+++ b/parser/msch_CommPrefLexpr.0
@@ -1,0 +1,3 @@
+hello()
+	head head (id * 3); 
+end;

--- a/parser/msch_CommPrefLexpr.2
+++ b/parser/msch_CommPrefLexpr.2
@@ -1,0 +1,4 @@
+hello()
+// that would be expr expr, needs brackets due to prefix term
+	head head id * 3; 
+end;


### PR DESCRIPTION
... head|tail prefixlist term should work

looking at the grammar, HEAD | TAIL Expr; cannot work
the conflict in the definition stems from **Expr: { not | head | tail | islist } Term**;

without modification, my parser would reduce Head Expr ; or Head Term ; to Lexpr ; , which is not valid
if we have prefixed statements on the left without an assignment, these can only come from **Expr: { not | head | tail | islist } Term**, so head | tail Expr as Statement should not be valid, only with brackets that come from Term. 
My tests test that behaviour.