### PR TITLE
Add tests for missing semicolons and empty stat

### DIFF
--- a/parser/m-gail_emptyStat.2
+++ b/parser/m-gail_emptyStat.2
@@ -1,0 +1,3 @@
+stat()
+    ; // stats cannot be empty
+end;

--- a/parser/m-gail_funcNoSemicolon.2
+++ b/parser/m-gail_funcNoSemicolon.2
@@ -1,0 +1,3 @@
+no_semicolon()
+    print();
+end // there should be a ; here

--- a/parser/m-gail_labelSemicolon.2
+++ b/parser/m-gail_labelSemicolon.2
@@ -1,0 +1,4 @@
+label()
+    label:; // labels cannot have a ; afterwards
+    print();
+end;


### PR DESCRIPTION
I added tests for the following cases
* Funcdefs always have to end with ';'
* A stat may not be empty, so a single ';' should be invalid
* In Stats, a Stat must have a ';', but a Label may not have one